### PR TITLE
Add. TabContents ui 구현완료 및 tab 클릭시 활성화

### DIFF
--- a/src/components/ProfileSection/ProfileSection.js
+++ b/src/components/ProfileSection/ProfileSection.js
@@ -36,7 +36,7 @@ export default function ProfileSection() {
 const Profile = styled.div`
   position: relative;
   width: 700px;
-  margin: 0 auto;
+  margin: 0 auto 94px;
   padding: 35px 0 0;
 `;
 

--- a/src/components/TabContents/TabContents.js
+++ b/src/components/TabContents/TabContents.js
@@ -1,0 +1,44 @@
+import { useState } from 'react';
+import styled from 'styled-components';
+
+export default function TabContents() {
+  const [activeTab, setActiveTab] = useState('글');
+
+  const clickTab = event => {
+    setActiveTab(event.target.innerText);
+  };
+
+  const Contents = ['소개', '글', '시리즈'];
+
+  return (
+    <Tabs>
+      {Contents.map((el, index) => {
+        return (
+          <Tab key={index} isActive={el === activeTab} onClick={clickTab}>
+            {el}
+          </Tab>
+        );
+      })}
+    </Tabs>
+  );
+}
+
+const Tabs = styled.nav`
+  display: flex;
+  margin: 0 auto;
+  width: 700px;
+  box-shadow: inset 0 -1px 0 rgb(230 230 230);
+`;
+
+const Tab = styled.span`
+  display: block;
+  margin-right: 32px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid
+    ${props => (props.isActive ? '#333' : 'rgb(230 230 230)')};
+  min-width: max-content;
+  color: ${props => (props.isActive ? '#333' : '#959595')};
+  font-size: 14px;
+  line-height: 20px;
+  cursor: pointer;
+`;

--- a/src/pages/Contents/Contents.js
+++ b/src/pages/Contents/Contents.js
@@ -1,12 +1,13 @@
 import Nav from '../../components/Nav/Nav';
 import ProfileSection from '../../components/ProfileSection/ProfileSection';
+import TabContents from '../../components/TabContents/TabContents';
 
 export default function Contents() {
   return (
     <>
       <Nav />
       <ProfileSection />
-      <h1>된다!</h1>
+      <TabContents />
     </>
   );
 }


### PR DESCRIPTION
## :: 최근 작업 주제
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표
- Tab Contents ui 구현 및 클릭시 활성화
<br />

## :: 구현 사항 설명
1. Tab Contents 활성화
- 클릭시 state에 tab명이 들어가게 한다.
- styled component에 props로 state와 요소의 값을 비교하는 boolean값을 전달한다.
- 전달된 props를 이용해서 삼항연산자로 스타일을 적용시킨다.

<br />

## :: 기타 질문 및 특이 사항
- 추후에 state를 끌어올려 적용시킬지 전역관리를 할 지 생각해봐야 할 것 같다.(클릭한 탭에 따라서 아래에 렌더링되는 데이터가 달라짐)