### PR TITLE
Modify. nav에 search btn안에 아이콘 위치 수정

### DIFF
--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -102,10 +102,11 @@ const SearchInput = styled.input`
 const SearchBtn = styled.button`
   position: absolute;
   top: 50%;
-  right: 1px;
+  right: 6.5px;
   transform: translateY(-50%);
   z-index: 10;
-  padding: none;
+  margin: 0;
+  padding: 0;
   border: none;
   background-color: transparent;
   cursor: pointer;

--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -102,11 +102,12 @@ const SearchInput = styled.input`
 const SearchBtn = styled.button`
   position: absolute;
   top: 50%;
-  right: 6.5px;
+  right: 0;
   transform: translateY(-50%);
   z-index: 10;
   margin: 0;
   padding: 0;
+  width: 30px;
   border: none;
   background-color: transparent;
   cursor: pointer;


### PR DESCRIPTION
## :: 최근 작업 주제
- [ ] 기능 추가
- [ ] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표
- nav에 search btn안에 아이콘 위치 수정
<br />

## :: 구현 사항 설명
1. nav에 search btn안에 아이콘 위치 수정
- padding 은 none 값 없음 -> 0으로 수정
- margin -> 0
- width: 30px, right:0 으로 위치 고정

<br />

## :: 성장 포인트
- safari에는 search 버튼의 위치가 이상하게 위치
- button 태그의 경우 브라우저마다 기본값이 달라서 다르게 보일 수 있음 -> 확인해줘야함

<br />

## :: 기타 질문 및 특이 사항
- width를 30px로 하드코딩해줬는데 더 좋은 방법이 있는 지 생각해봐야한다.