### PR TITLE
Hotfix. 블로그 타이틀 클릭 시 버튼 state 변경되는 오류 고침

### DIFF
--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -50,7 +50,7 @@ export default function Nav() {
                 to="/blog-project-v0.0/"
                 titleTogle={titleTogle}
               >
-                <BlogTitle onClick={clickTilte}>{navData.blogTitle}</BlogTitle>
+                <BlogTitle>{navData.blogTitle}</BlogTitle>
               </BlogTitleWrapLink>
             </BlogLogoTitle>
           </BlogLogoTitleWrap>

--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -124,7 +124,7 @@ const BlogLogoTitleWrap = styled.div`
 const BlogLogoTitle = styled.div`
   /* position: absolute; */
   transform: ${props =>
-    props.titleTogle ? 'translate(0)' : 'translateY(-50px)'};
+    props.titleTogle ? 'translate(0)' : 'translateY(-51px)'};
   transition: transform 0.3s;
 `;
 


### PR DESCRIPTION
## :: 최근 작업 주제
- [ ] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정

## :: 구현 사항 설명
1. 블로그 타이틀 클릭 시 버튼 state 변경되는 오류 고침
- blog title 태그에 이벤트 잘못 들어가 있었음

2. 움직이는 div의 height가 2px 늘어나서 그만큼 translate 변경